### PR TITLE
go.mod: upgrade to go1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
 
     - name: Checkout code
       uses: actions/checkout@v2
@@ -18,13 +18,13 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
 

--- a/encoding/json5/encode.go
+++ b/encoding/json5/encode.go
@@ -148,7 +148,7 @@ func (m *marshaler) writeKey(s string) (int, error) {
 func (m *marshaler) MarshalValue(v reflect.Value) (bool, error) {
 	switch marshaler := v.Interface().(type) {
 	case json.Marshaler:
-		if v.Kind() == reflect.Ptr && v.IsNil() {
+		if v.Kind() == reflect.Pointer && v.IsNil() {
 			return true, m.MarshalNil()
 		}
 		txt, err := marshaler.MarshalJSON()

--- a/encoding/toml/encode.go
+++ b/encoding/toml/encode.go
@@ -106,7 +106,7 @@ func (m *marshaler) writeKeyPath(s []string) error {
 }
 
 func isValueType(v reflect.Value) bool {
-	for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+	for v.Kind() == reflect.Interface || v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	if !v.IsValid() {
@@ -114,7 +114,7 @@ func isValueType(v reflect.Value) bool {
 		return true
 	}
 	t := v.Type()
-	for t.Kind() == reflect.Ptr {
+	for t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	if reflectutil.IsValueType(t) {
@@ -126,7 +126,7 @@ func isValueType(v reflect.Value) bool {
 		}
 		for i := 0; i < v.Len(); i++ {
 			elem := v.Index(i)
-			for elem.Kind() == reflect.Interface || elem.Kind() == reflect.Ptr {
+			for elem.Kind() == reflect.Interface || elem.Kind() == reflect.Pointer {
 				elem = elem.Elem()
 			}
 			ok := isValueType(elem)
@@ -349,7 +349,7 @@ func (m *marshaler) MarshalMapKey(mv reflect.Value, kv reflectutil.MapEntry, i i
 		}
 		m.first = false
 	} else {
-		for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		for v.Kind() == reflect.Interface || v.Kind() == reflect.Pointer {
 			v = v.Elem()
 		}
 		if !reflectutil.IsList(v.Type()) {
@@ -414,7 +414,7 @@ func (m *marshaler) MarshalMapValuePost(mv reflect.Value, kv reflectutil.MapEntr
 			}
 		}
 	} else {
-		for v.Kind() == reflect.Interface || v.Kind() == reflect.Ptr {
+		for v.Kind() == reflect.Interface || v.Kind() == reflect.Pointer {
 			v = v.Elem()
 		}
 		if !reflectutil.IsList(v.Type()) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module snai.pe/boa
 
-go 1.16
+go 1.18

--- a/internal/encutil/decoder.go
+++ b/internal/encutil/decoder.go
@@ -33,7 +33,7 @@ type MultiFile interface {
 
 func (unmarshaler *UnmarshalerBase) Decode(in io.Reader, v interface{}) error {
 	ptr := reflect.ValueOf(v)
-	if ptr.Kind() != reflect.Ptr {
+	if ptr.Kind() != reflect.Pointer {
 		panic("decode: must pass in pointer value")
 	}
 

--- a/internal/reflectutil/env.go
+++ b/internal/reflectutil/env.go
@@ -34,7 +34,7 @@ func UnmarshalText(to reflect.Value, value string) (bool, error) {
 
 	switch kind := to.Kind(); kind {
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		ptr := reflect.New(to.Type().Elem())
 		ok, err := UnmarshalText(ptr, value)
 		if ok && err == nil {
@@ -96,7 +96,7 @@ func PopulateFromEnv(to reflect.Value, automatic bool, names []string, lookup fu
 		return true, nil
 	}
 
-	if to.Kind() == reflect.Ptr {
+	if to.Kind() == reflect.Pointer {
 		if !to.IsNil() {
 			return PopulateFromEnv(to.Elem(), automatic, names, lookup)
 		}

--- a/internal/reflectutil/marshal.go
+++ b/internal/reflectutil/marshal.go
@@ -151,7 +151,7 @@ func Marshal(val reflect.Value, marshaler Marshaler, convention NamingConvention
 	}
 
 	switch kind := val.Kind(); kind {
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		if val.IsNil() {
 			m, ok := marshaler.(NilMarshaler)
 			if !ok {
@@ -259,7 +259,7 @@ func Marshal(val reflect.Value, marshaler Marshaler, convention NamingConvention
 		for i, kv := range kvs {
 			// If the value is nil, and we can't represent nil in the format,
 			// just omit the field entirely. There isn't much else sensible we can do.
-			if (kv.Value.Kind() == reflect.Ptr || kv.Value.Kind() == reflect.Interface) && kv.Value.IsNil() {
+			if (kv.Value.Kind() == reflect.Pointer || kv.Value.Kind() == reflect.Interface) && kv.Value.IsNil() {
 				if _, ok := marshaler.(NilMarshaler); !ok {
 					continue
 				}
@@ -299,7 +299,7 @@ func Marshal(val reflect.Value, marshaler Marshaler, convention NamingConvention
 		for i, kv := range kvs {
 			// If the value is nil, and we can't represent nil in the format,
 			// just omit the field entirely. There isn't much else sensible we can do.
-			if (kv.Value.Kind() == reflect.Ptr || kv.Value.Kind() == reflect.Interface) && kv.Value.IsNil() {
+			if (kv.Value.Kind() == reflect.Pointer || kv.Value.Kind() == reflect.Interface) && kv.Value.IsNil() {
 				if _, ok := marshaler.(NilMarshaler); !ok {
 					continue
 				}
@@ -364,7 +364,7 @@ func IsValueType(t reflect.Type) bool {
 // If v is a struct, it returns the number of fields
 // For everything else, Len returns 1.
 func Len(v reflect.Value) int {
-	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+	for v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
 	switch v.Kind() {

--- a/internal/reflectutil/unmarshal.go
+++ b/internal/reflectutil/unmarshal.go
@@ -105,7 +105,7 @@ func unmarshal(val reflect.Value, node *syntax.Node, convention encoding.NamingC
 
 	switch kind := val.Kind(); kind {
 
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if node.Type == syntax.NodeNil {
 			// We have an explicit nil, therefore we must set the pointer to nil.
 			val.Set(reflect.Zero(typ))
@@ -306,7 +306,7 @@ func Set(val reflect.Value, node *syntax.Node, convention encoding.NamingConvent
 	}
 
 	switch kind := val.Kind(); kind {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if val.IsNil() {
 			val.Set(reflect.New(val.Type().Elem()))
 		}
@@ -339,7 +339,7 @@ func Set(val reflect.Value, node *syntax.Node, convention encoding.NamingConvent
 
 	velem := reflect.ValueOf(elem)
 	switch kind := rval.Kind(); kind {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if rval.IsNil() {
 			rval.Set(reflect.New(typ.Elem()))
 			val.Set(rval)

--- a/internal/reflectutil/walk.go
+++ b/internal/reflectutil/walk.go
@@ -16,13 +16,13 @@ func DeepEqual(lhs, rhs interface{}, fn func(lhs, rhs reflect.Value) (bool, erro
 }
 
 func deepEqual(lhs, rhs reflect.Value, fn func(lhs, rhs reflect.Value) (bool, error)) error {
-	for lhs.Kind() == reflect.Ptr {
+	for lhs.Kind() == reflect.Pointer {
 		if lhs.IsNil() {
 			break
 		}
 		lhs = lhs.Elem()
 	}
-	for rhs.Kind() == reflect.Ptr {
+	for rhs.Kind() == reflect.Pointer {
 		if rhs.IsNil() {
 			break
 		}
@@ -39,7 +39,7 @@ func deepEqual(lhs, rhs reflect.Value, fn func(lhs, rhs reflect.Value) (bool, er
 	}
 
 	switch lhs.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		if lhs.IsNil() != rhs.IsNil() {
 			return fmt.Errorf("one value is nil while the other isn't")
 		}

--- a/path_generic.go
+++ b/path_generic.go
@@ -4,7 +4,6 @@
 // found in the LICENSE file.
 
 //go:build !darwin && !windows
-// +build !darwin,!windows
 
 package boa
 


### PR DESCRIPTION
Main motivator for this was broken CI due to usage of reflect.Pointer,
the go 1.18 is still an ancient go release so it has been deemed safe
to just bump the version.