### PR TITLE
fileset: expose full path during error reporting

### DIFF
--- a/fileset.go
+++ b/fileset.go
@@ -160,6 +160,10 @@ func (cfg *FileSet) Next(exts ...string) error {
 				case errors.Is(err, fs.ErrNotExist):
 					continue
 				case err != nil:
+					pathError := &fs.PathError{}
+					if ok := errors.As(err, &pathError); ok {
+						pathError.Path = filepath.Join(fsPath(cfg.fs[cfg.fsIndex]), stem, ext)
+					}
 					return err
 				}
 				cfg.used = append(cfg.used, fmt.Sprintf("%v/%v%v", fsPath(cfg.fs[cfg.fsIndex]), stem, ext))


### PR DESCRIPTION
fs.FS interface demands *PathError instances returned from Open have their Path field set to `name` of the file. This is fine, when treating fs.FS as a bespoke go-based chroot. However for purposes of error reporting in library that operates on multiple such fs.FS instances, returning just a name of a file is insufficient when identifying problematic paths.

This change exposes the absolute path of a file of which open operation failed, allowing users to better identify problematic paths.